### PR TITLE
[Bugfix] Fixing bug inside MultiModalProfiler.

### DIFF
--- a/tests/models/multimodal/processing/test_mllama4.py
+++ b/tests/models/multimodal/processing/test_mllama4.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for mllama's multimodal preprocessing and profiling."""
+import pytest
+from torch import prod
+from transformers import Llama4Config
+
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.profiling import MultiModalProfiler
+
+from ...utils import build_model_context
+
+
+@pytest.mark.parametrize("model_id", ["meta-llama/Llama-Guard-4-12B"])
+@pytest.mark.parametrize("max_model_len", [4096, 8192, 25600, 131072])
+def test_profiling(
+    model_id: str,
+    max_model_len: int,
+):
+
+    model_config_kwargs = {
+        "max_model_len": max_model_len,
+    }
+    ctx = build_model_context(
+        model_id,
+        model_config_kwargs=model_config_kwargs,
+        limit_mm_per_prompt={"image": 1},
+    )
+
+    mm_config = ctx.get_mm_config()
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+    profiler = MultiModalProfiler(processor)
+
+    decoder_dummy_data = profiler.get_decoder_dummy_data(
+        max_model_len,
+        mm_counts=mm_config.limit_per_prompt,
+    )
+    dummy_mm_data = processor.dummy_inputs.get_dummy_processor_inputs(
+        max_model_len,
+        mm_counts=mm_config.limit_per_prompt,
+    )
+
+    hf_config = ctx.get_hf_config(Llama4Config)
+
+    mm_kwargs = processor.apply(
+        prompt=dummy_mm_data.prompt,
+        mm_data=dummy_mm_data.mm_data,
+        hf_processor_mm_kwargs=dict(),
+    )["mm_kwargs"]
+
+    image_size = hf_config.vision_config.image_size
+    patch_size = hf_config.vision_config.patch_size
+    downsample_ratio = int(
+        round(1.0 / (hf_config.vision_config.pixel_shuffle_ratio**2)))
+    tokens_per_patch = ((image_size // patch_size)**2) // downsample_ratio
+    chunks_per_image = prod(mm_kwargs["patches_per_image"])
+    total_num_patches = chunks_per_image * tokens_per_patch
+    num_tiles = mm_kwargs["aspect_ratios"][0][0] * mm_kwargs["aspect_ratios"][
+        0][1]  # x-y seperator tokens
+    total_tokens = total_num_patches.item() + num_tiles.item(
+    ) + 3  # image start, image, image end
+
+    profiled_tokens = profiler.get_mm_max_tokens(
+        max_model_len,
+        mm_counts=mm_config.limit_per_prompt,
+    )
+
+    assert total_tokens == profiled_tokens["image"]
+    assert total_tokens == sum(
+        placeholder.length for placeholder in
+        decoder_dummy_data.multi_modal_placeholders["image"])

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -359,7 +359,9 @@ _MULTIMODAL_EXAMPLE_MODELS = {
                                                       extras={"thinking": "moonshotai/Kimi-VL-A3B-Thinking"},  # noqa: E501
                                                       trust_remote_code=True),
     "Llama4ForConditionalGeneration": _HfExamplesInfo("meta-llama/Llama-4-Scout-17B-16E-Instruct",   # noqa: E501
-                                                      max_model_len=10240),
+                                                      max_model_len=10240,
+                                                      extras={"llama-guard-4": "meta-llama/Llama-Guard-4-12B"}, # noqa: E501
+                                                      ),
     "LlavaForConditionalGeneration": _HfExamplesInfo("llava-hf/llava-1.5-7b-hf",
                                                      extras={"mistral": "mistral-community/pixtral-12b", # noqa: E501
                                                              "mistral-fp8": "nm-testing/pixtral-12b-FP8-dynamic"}),  # noqa: E501

--- a/vllm/multimodal/profiling.py
+++ b/vllm/multimodal/profiling.py
@@ -184,7 +184,7 @@ class MultiModalProfiler(Generic[_I]):
         placeholders_by_modality = mm_inputs["mm_placeholders"]
 
         return {
-            modality: sum(item.get_num_embeds() for item in placeholders)
+            modality: sum(item.length for item in placeholders)
             for modality, placeholders in placeholders_by_modality.items()
         }
 


### PR DESCRIPTION
## Purpose
This PR fixes the issue #21344 where large image requests hangs in vllm waiting for the request to timeout.
**Bug:** MultiModalProfiler counts only `patch` tokens but, there are other bookeeping tokens like `tile_seperator`, `image_start`, `image_end` tokens in the input. This causes the encoder_budget to be slightly lower the actual budget. Whenever an image that uses all tiles is sent, VLLM accept the request but, scheduler can never schedule it because there is not enough encoder budget. Silent issue and No error is produced

**Fix:** Use the length parameter on `PlaceHolderRange` instead of embedding which is real token budget during profiling.

## Test Plan
1. Large image ( 4k x 4k) - LLama Guard 4
2. Full Context length Text + Large image + Llama Guard 4
3. Sanity test with (7k x 4k Image)
## Test Result
1. Large image ( 4k x 4k)
```
{
    "id": "chatcmpl-464e45d8a7834c41aa96b93c388f5be6",
    "object": "chat.completion",
    "created": 1753798054,
    "model": "vllm-model",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "\n\nsafe",
                "refusal": null,
                "annotations": null,
                "audio": null,
                "function_call": null,
                "tool_calls": [],
                "reasoning_content": null
            },
            "logprobs": null,
            "finish_reason": "stop",
            "stop_reason": null
        }
    ],
    "service_tier": null,
    "system_fingerprint": null,
    "usage": {
        "prompt_tokens": 2669,
        "total_tokens": 2672,
        "completion_tokens": 3,
        "prompt_tokens_details": null
    },
    "prompt_logprobs": null,
    "kv_transfer_params": null
}
```
2. Full Context length Text + Large image (2467 is the encoder budget)
```
{
    "id": "chatcmpl-9406bb1facd54ea194a270fed2577ca8",
    "object": "chat.completion",
    "created": 1753798730,
    "model": "vllm-model",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "0",
                "refusal": null,
                "annotations": null,
                "audio": null,
                "function_call": null,
                "tool_calls": [],
                "reasoning_content": null
            },
            "logprobs": null,
            "finish_reason": "stop",
            "stop_reason": 200001
        }
    ],
    "service_tier": null,
    "system_fingerprint": null,
    "usage": {
        "prompt_tokens": 131069,
        "total_tokens": 131071,
        "completion_tokens": 2,
        "prompt_tokens_details": null
    },
    "prompt_logprobs": null,
    "kv_transfer_params": null
}
```

3. Sanity Test
```
curl http: //localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
    "messages": [
        {
            "role": "user",
            "content": [
                {
                    "type": "image_url",
                    "image_url": {
                        "url": "https://upload.wikimedia.org/wikipedia/commons/8/85/Portas_da_Cidade%2C_Ponta_Delgada%2C_isla_de_San_Miguel%2C_Azores%2C_Portugal%2C_2020-07-29%2C_DD_123-125_HDR.jpg"
                    }
                },
                {
                    "type": "text",
                    "text": "Describe this image in detail and also specify where this can be found."
                }
            ]
        }
    ],
    "model": "vllm"
}'
{
    "id": "chatcmpl-86908cb63b644decbcfcbc63d26fbb36",
    "object": "chat.completion",
    "created": 1753799599,
    "model": "vllm",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "The image depicts a large, ornate archway in the center of a city square at dusk. The archway is made of stone and features two large arches with a decorative top section. It is illuminated by purple lights on either side.\n\nHere are the main points describing the image:\n\n* **Archway**\n\t+ Made of stone\n\t+ Features two large arches\n\t+ Decorative top section with a crown-like design\n\t+ Illuminated by purple lights on either side\n* **City Square**\n\t+ Located in front of the archway\n\t+ Features a statue in the center\n\t+ Surrounded by buildings on all sides\n\t+ Streetlights and cars visible\n* **Buildings**\n\t+ White with brown trim\n\t+ Feature arched windows and doors\n\t+ Have balconies on the second floor\n\t+ Appear to be old and historic\n* **Statue**\n\t+ Located in the center of the square\n\t+ Depicts a person standing on a pedestal\n\t+ Not clearly visible due to distance\n* **Streetlights and Cars**\n\t+ Streetlights line the square and surrounding streets\n\t+ Cars are parked along the streets and driving through the area\n\t+ Traffic lights visible in the distance\n* **Sky**\n\t+ Dark blue and cloudy\n\t+ Indicates that it is dusk or evening\n\nIn summary, the image shows a beautiful and historic archway in a city square, surrounded by old buildings and a statue. The archway is illuminated by purple lights, and the square is bustling with streetlights and cars. The dark blue sky suggests that it is dusk or evening. \n\nThis archway can be found in Horta, Faial, Azores, Portugal. The archway is known as the Portão da Cidade (City Gate) and is a iconic landmark in Horta.",
                "refusal": null,
                "annotations": null,
                "audio": null,
                "function_call": null,
                "tool_calls": [],
                "reasoning_content": null
            },
            "logprobs": null,
            "finish_reason": "stop",
            "stop_reason": null
        }
    ],
    "service_tier": null,
    "system_fingerprint": null,
    "usage": {
        "prompt_tokens": 2346,
        "total_tokens": 2732,
        "completion_tokens": 386,
        "prompt_tokens_details": null
    },
    "prompt_logprobs": null,
    "kv_transfer_params": null
}

```
## (Optional) Documentation Update

