### PR TITLE
Fix upstream tag sync on tag conflicts

### DIFF
--- a/.github/workflows/create-feature-branches.yml
+++ b/.github/workflows/create-feature-branches.yml
@@ -202,7 +202,8 @@ jobs:
             --title "Cherry-pick: $PREVIOUS_BRANCH_NAME → $BRANCH_NAME" \
             --body "$PR_BODY" \
             --base "$BRANCH_NAME" \
-            --head "$PR_BRANCH"
+            --head "$CONFLICT_BRANCH" \
+            --reviewer "CatherineSue,shenoyvvarun,slin1237,YouNeedCryDear,upfixer,key4ng"
         env:
           GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -289,7 +290,8 @@ jobs:
             --title "Cherry-pick conflicts: $PREVIOUS_BRANCH_NAME → $BRANCH_NAME" \
             --body "$PR_BODY" \
             --base "$BRANCH_NAME" \
-            --head "$CONFLICT_BRANCH"
+            --head "$CONFLICT_BRANCH" \
+            --reviewer "CatherineSue,shenoyvvarun,slin1237,YouNeedCryDear,upfixer,key4ng"
         env:
           GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create-feature-branches.yml
+++ b/.github/workflows/create-feature-branches.yml
@@ -41,7 +41,55 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "branch_name=features-based-on-$TAG" >> $GITHUB_OUTPUT
 
-      - name: Check if branch already exists
+      - name: Find previous tag with existing branch
+        id: previous_tag
+        run: |
+          CURRENT_TAG="${{ steps.get_tag.outputs.tag }}"
+          
+          # Get all tags sorted by version (newest first)
+          ALL_TAGS=$(git tag --sort=-version:refname)
+          
+          # Find the position of current tag and get all tags after it (older versions)
+          FOUND_CURRENT=false
+          PREVIOUS_TAG_WITH_BRANCH=""
+          PREVIOUS_BRANCH_NAME=""
+          
+          echo "Searching for previous tag with existing feature branch..."
+          echo "Current tag: $CURRENT_TAG"
+          
+          for tag in $ALL_TAGS; do
+            if [[ "$FOUND_CURRENT" == "true" ]]; then
+              # This is a previous tag, check if it has a feature branch
+              CANDIDATE_BRANCH="features-based-on-$tag"
+              echo "Checking if branch exists for tag $tag: $CANDIDATE_BRANCH"
+              
+              if git ls-remote --heads origin "$CANDIDATE_BRANCH" | grep -q "$CANDIDATE_BRANCH"; then
+                echo "Found previous tag with branch: $tag -> $CANDIDATE_BRANCH"
+                PREVIOUS_TAG_WITH_BRANCH="$tag"
+                PREVIOUS_BRANCH_NAME="$CANDIDATE_BRANCH"
+                break
+              else
+                echo "No branch found for tag $tag"
+              fi
+            elif [[ "$tag" == "$CURRENT_TAG" ]]; then
+              FOUND_CURRENT=true
+              echo "Found current tag position in list"
+            fi
+          done
+          
+          if [[ -z "$PREVIOUS_TAG_WITH_BRANCH" ]]; then
+            echo "No previous tag with existing feature branch found"
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "tag=" >> $GITHUB_OUTPUT
+            echo "branch_name=" >> $GITHUB_OUTPUT
+          else
+            echo "Found previous tag with branch: $PREVIOUS_TAG_WITH_BRANCH"
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "tag=$PREVIOUS_TAG_WITH_BRANCH" >> $GITHUB_OUTPUT
+            echo "branch_name=$PREVIOUS_BRANCH_NAME" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check if current branch already exists
         id: check_branch
         run: |
           BRANCH_NAME="${{ steps.get_tag.outputs.branch_name }}"
@@ -51,6 +99,32 @@ jobs:
           else
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "Branch $BRANCH_NAME does not exist"
+          fi
+
+      - name: Get commits to cherry-pick
+        id: get_commits
+        if: steps.previous_tag.outputs.exists == 'true'
+        run: |
+          PREVIOUS_TAG="${{ steps.previous_tag.outputs.tag }}"
+          PREVIOUS_BRANCH_NAME="${{ steps.previous_tag.outputs.branch_name }}"
+          
+          # Fetch the previous branch
+          git fetch origin "$PREVIOUS_BRANCH_NAME:$PREVIOUS_BRANCH_NAME"
+          
+          # Get commits between the previous tag and HEAD of previous branch
+          COMMITS=$(git rev-list --reverse "$PREVIOUS_TAG..origin/$PREVIOUS_BRANCH_NAME")
+          
+          if [[ -z "$COMMITS" ]]; then
+            echo "No commits to cherry-pick"
+            echo "has_commits=false" >> $GITHUB_OUTPUT
+            echo "commits=" >> $GITHUB_OUTPUT
+          else
+            echo "Commits to cherry-pick:"
+            echo "$COMMITS"
+            echo "has_commits=true" >> $GITHUB_OUTPUT
+            # Convert newlines to spaces for GitHub Actions
+            COMMITS_ONELINE=$(echo "$COMMITS" | tr '\n' ' ')
+            echo "commits=$COMMITS_ONELINE" >> $GITHUB_OUTPUT
           fi
 
       - name: Create feature branch
@@ -64,6 +138,160 @@ jobs:
           git push origin "$BRANCH_NAME"
 
           echo "Created branch: $BRANCH_NAME from tag: $TAG"
+
+      - name: Cherry-pick commits
+        id: cherry_pick
+        if: steps.check_branch.outputs.exists == 'false' && steps.get_commits.outputs.has_commits == 'true'
+        run: |
+          BRANCH_NAME="${{ steps.get_tag.outputs.branch_name }}"
+          COMMITS="${{ steps.get_commits.outputs.commits }}"
+          
+          git checkout "$BRANCH_NAME"
+          
+          # Try cherry-picking commits
+          CONFLICT_OCCURRED=false
+          for commit in $COMMITS; do
+            echo "Cherry-picking commit: $commit"
+            if ! git cherry-pick "$commit"; then
+              echo "Conflict occurred while cherry-picking $commit"
+              CONFLICT_OCCURRED=true
+              # Abort the cherry-pick to clean state
+              git cherry-pick --abort
+              break
+            fi
+          done
+          
+          if [[ "$CONFLICT_OCCURRED" == "true" ]]; then
+            echo "conflict=true" >> $GITHUB_OUTPUT
+            echo "Conflicts detected during cherry-pick"
+          else
+            echo "conflict=false" >> $GITHUB_OUTPUT
+            echo "All commits cherry-picked successfully"
+          fi
+
+      - name: Create PR for successful cherry-pick
+        if: steps.check_branch.outputs.exists == 'false' && steps.get_commits.outputs.has_commits == 'true' && steps.cherry_pick.outputs.conflict == 'false'
+        run: |
+          BRANCH_NAME="${{ steps.get_tag.outputs.branch_name }}"
+          PREVIOUS_BRANCH_NAME="${{ steps.previous_tag.outputs.branch_name }}"
+          PREVIOUS_TAG="${{ steps.previous_tag.outputs.tag }}"
+          CURRENT_TAG="${{ steps.get_tag.outputs.tag }}"
+          COMMITS="${{ steps.get_commits.outputs.commits }}"
+          
+          # Create a new branch for the PR
+          PR_BRANCH="pr-$BRANCH_NAME"
+          git checkout -b "$PR_BRANCH" "$BRANCH_NAME"
+          git push origin "$PR_BRANCH"
+          
+          # Create PR using GitHub CLI or API
+          COMMIT_LIST_MD=$(echo $COMMITS | tr ' ' '\n' | while read commit; do echo "- $commit"; done)
+          
+          # Create PR body content
+          PR_BODY="## Cherry-pick: $PREVIOUS_BRANCH_NAME → $BRANCH_NAME
+
+          This PR contains cherry-picked commits from \`$PREVIOUS_BRANCH_NAME\` to \`$BRANCH_NAME\`.
+
+          **Source:** \`$PREVIOUS_BRANCH_NAME\` (commits after tag \`$PREVIOUS_TAG\`)
+          **Target:** \`$BRANCH_NAME\` (based on tag \`$CURRENT_TAG\`)
+
+          **Commits to cherry-pick:**
+          $COMMIT_LIST_MD
+          "
+          
+          gh pr create \
+            --title "Cherry-pick: $PREVIOUS_BRANCH_NAME → $BRANCH_NAME" \
+            --body "$PR_BODY" \
+            --base "$BRANCH_NAME" \
+            --head "$PR_BRANCH"
+        env:
+          GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Create PR for conflicts
+        if: steps.cherry_pick.outputs.conflict == 'true'
+        run: |
+          BRANCH_NAME="${{ steps.get_tag.outputs.branch_name }}"
+          PREVIOUS_BRANCH_NAME="${{ steps.previous_tag.outputs.branch_name }}"
+          PREVIOUS_TAG="${{ steps.previous_tag.outputs.tag }}"
+          CURRENT_TAG="${{ steps.get_tag.outputs.tag }}"
+          COMMITS="${{ steps.get_commits.outputs.commits }}"
+          
+          # Create a conflict resolution branch
+          CONFLICT_BRANCH="cherry-pick-conflicts-$BRANCH_NAME"
+          git checkout -b "$CONFLICT_BRANCH" "$BRANCH_NAME"
+          
+          # Create an empty commit to establish the branch and enable PR creation
+          COMMIT_LIST=$(echo $COMMITS | tr ' ' '\n' | while read commit; do git log --oneline -1 $commit 2>/dev/null || echo $commit; done)
+          
+          # Now attempt the merge - conflicts will be left in proper Git state
+          if ! git merge origin/"$PREVIOUS_BRANCH_NAME" --no-ff -m "Cherry-pick commits from $PREVIOUS_BRANCH_NAME"; then
+            echo "Merge conflicts detected. Committing conflict markers so they can be pushed."
+            
+            # Capture conflicted files before staging
+            CONFLICTED_FILES=$(git diff --name-only --diff-filter=U | tr '\n' ' ')
+            
+            # Add all files including conflict markers
+            git add .
+            
+            # Commit the conflict markers with clear documentation
+            git commit -m "🚧 CONFLICTS: Cherry-pick from $PREVIOUS_BRANCH_NAME to $BRANCH_NAME
+
+            ⚠️  This commit contains unresolved merge conflicts in files:
+            $CONFLICTED_FILES
+
+            Commits being cherry-picked:
+            $COMMIT_LIST
+
+            📝 Edit files to remove conflict markers"
+            
+            # Push the conflict markers
+            git push origin "$CONFLICT_BRANCH"
+          else
+            echo "Merge completed successfully without conflicts."
+            git push origin "$CONFLICT_BRANCH"  # Push the successful merge
+          fi
+          
+          # Create PR using GitHub CLI or API
+          COMMIT_LIST_MD=$(echo $COMMITS | tr ' ' '\n' | while read commit; do echo "- $commit"; done)
+          
+          # Create PR body content
+          PR_BODY="## 🚧 Cherry-pick Conflicts Need Resolution
+
+          This PR contains merge conflicts from cherry-picking commits from \`$PREVIOUS_BRANCH_NAME\` to \`$BRANCH_NAME\`.
+
+          **Source:** \`$PREVIOUS_BRANCH_NAME\` (commits after tag \`$PREVIOUS_TAG\`)
+          **Target:** \`$BRANCH_NAME\` (based on tag \`$CURRENT_TAG\`)
+
+          **Commits to cherry-pick:**
+          $COMMIT_LIST_MD
+
+          ## 🛠️ How to resolve conflicts:
+
+          1. **Checkout this branch:**
+            \`\`\`bash
+            git fetch origin && git checkout $CONFLICT_BRANCH
+            \`\`\`
+
+          2. **Resolve conflicts using IDE tools or manually:**
+            - **VS Code**: Automatically detects \`<<<<<<<\`, \`=======\`, \`>>>>>>>\` markers and shows merge conflict UI
+            - **Other IDEs**: Most modern IDEs detect conflict markers automatically
+            - **Manual**: Edit files to remove conflict markers and choose the correct code
+
+          3. **Commit the resolution:**
+            \`\`\`bash
+            git add resolved-files
+            git commit -m \"✅ Resolved: Cherry-pick from $PREVIOUS_BRANCH_NAME to $BRANCH_NAME\"
+            git push origin $CONFLICT_BRANCH
+            \`\`\`
+
+          🎯 **No force push needed!**"
+          
+          gh pr create \
+            --title "Cherry-pick conflicts: $PREVIOUS_BRANCH_NAME → $BRANCH_NAME" \
+            --body "$PR_BODY" \
+            --base "$BRANCH_NAME" \
+            --head "$CONFLICT_BRANCH"
+        env:
+          GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Skip if branch exists
         if: steps.check_branch.outputs.exists == 'true'

--- a/.github/workflows/create-feature-branches.yml
+++ b/.github/workflows/create-feature-branches.yml
@@ -12,7 +12,39 @@ on:
         type: string
 
 jobs:
+  check-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      is_prerelease: ${{ steps.check.outputs.is_prerelease }}
+      tag: ${{ steps.check.outputs.tag }}
+      branch_name: ${{ steps.check.outputs.branch_name }}
+    steps:
+      - name: Check if tag is pre-release
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          
+          # Check if this is a release candidate or pre-release tag
+          # Skip tags with .rc, -rc, rc (no separator), .alpha, -beta, etc.
+          if [[ "$TAG" =~ [\.-]?(rc|alpha|beta|pre|dev)[0-9]*$ ]]; then
+            echo "::notice::Skipping pre-release tag: $TAG"
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+            echo "branch_name=" >> $GITHUB_OUTPUT
+          else
+            echo "::notice::Processing stable release tag: $TAG"
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+            echo "branch_name=features-based-on-$TAG" >> $GITHUB_OUTPUT
+          fi
+
   create-feature-branch:
+    needs: check-tag
+    if: needs.check-tag.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,16 +62,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Get tag name
+      - name: Set tag variables
         id: get_tag
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            TAG="${{ github.event.inputs.tag }}"
-          else
-            TAG="${GITHUB_REF#refs/tags/}"
-          fi
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "branch_name=features-based-on-$TAG" >> $GITHUB_OUTPUT
+          echo "tag=${{ needs.check-tag.outputs.tag }}" >> $GITHUB_OUTPUT
+          echo "branch_name=${{ needs.check-tag.outputs.branch_name }}" >> $GITHUB_OUTPUT
 
       - name: Find previous tag with existing branch
         id: previous_tag
@@ -59,6 +86,12 @@ jobs:
           
           for tag in $ALL_TAGS; do
             if [[ "$FOUND_CURRENT" == "true" ]]; then
+              # Skip pre-release tags (same pattern as above)
+              if [[ "$tag" =~ [\.-]?(rc|alpha|beta|pre|dev)[0-9]*$ ]]; then
+                echo "Skipping pre-release tag: $tag"
+                continue
+              fi
+              
               # This is a previous tag, check if it has a feature branch
               CANDIDATE_BRANCH="features-based-on-$tag"
               echo "Checking if branch exists for tag $tag: $CANDIDATE_BRANCH"

--- a/.github/workflows/create-feature-branches.yml
+++ b/.github/workflows/create-feature-branches.yml
@@ -1,0 +1,71 @@
+name: Create Feature Branches from Tags
+
+on:
+  push:
+    tags:
+      - "v*" # Triggers on version tags like v1.0.0, v2.1.3, etc.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to create branch from"
+        required: true
+        type: string
+
+jobs:
+  create-feature-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Get tag name
+        id: get_tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "branch_name=features-based-on-$TAG" >> $GITHUB_OUTPUT
+
+      - name: Check if branch already exists
+        id: check_branch
+        run: |
+          BRANCH_NAME="${{ steps.get_tag.outputs.branch_name }}"
+          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Branch $BRANCH_NAME already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Branch $BRANCH_NAME does not exist"
+          fi
+
+      - name: Create feature branch
+        if: steps.check_branch.outputs.exists == 'false'
+        run: |
+          TAG="${{ steps.get_tag.outputs.tag }}"
+          BRANCH_NAME="${{ steps.get_tag.outputs.branch_name }}"
+
+          # Create branch from the tag
+          git checkout -b "$BRANCH_NAME" "$TAG"
+          git push origin "$BRANCH_NAME"
+
+          echo "Created branch: $BRANCH_NAME from tag: $TAG"
+
+      - name: Skip if branch exists
+        if: steps.check_branch.outputs.exists == 'true'
+        run: |
+          echo "Branch ${{ steps.get_tag.outputs.branch_name }} already exists. Skipping creation."

--- a/.github/workflows/create-feature-branches.yml
+++ b/.github/workflows/create-feature-branches.yml
@@ -15,11 +15,11 @@ jobs:
   check-tag:
     runs-on: ubuntu-latest
     outputs:
-      is_prerelease: ${{ steps.check.outputs.is_prerelease }}
+      skip_feature_branch_creation: ${{ steps.check.outputs.skip_feature_branch_creation }}
       tag: ${{ steps.check.outputs.tag }}
       branch_name: ${{ steps.check.outputs.branch_name }}
     steps:
-      - name: Check if tag is pre-release
+      - name: Check if tag should be processed
         id: check
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
@@ -28,23 +28,37 @@ jobs:
             TAG="${GITHUB_REF#refs/tags/}"
           fi
           
-          # Check if this is a release candidate or pre-release tag
-          # Skip tags with .rc, -rc, rc (no separator), .alpha, -beta, etc.
-          if [[ "$TAG" =~ [\.-]?(rc|alpha|beta|pre|dev)[0-9]*$ ]]; then
-            echo "::notice::Skipping pre-release tag: $TAG"
-            echo "is_prerelease=true" >> $GITHUB_OUTPUT
-            echo "tag=$TAG" >> $GITHUB_OUTPUT
-            echo "branch_name=" >> $GITHUB_OUTPUT
+          # Check if this is a pre-release tag
+          SKIP_CREATION=false
+          # Extract base version (e.g., v0.10.0 from v0.10.0rc1)
+          BASE_VERSION=$(echo "$TAG" | sed -E 's/[\.-]?(rc|alpha|beta|pre|dev)[0-9]*$//')
+          
+          if [[ "$TAG" != "$BASE_VERSION" ]]; then
+            # This is a pre-release tag (base version differs from tag)
+            # Check if corresponding full release exists
+            if git ls-remote --tags https://${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git | grep -q "refs/tags/$BASE_VERSION$"; then
+              echo "::notice::Skipping pre-release tag $TAG because full release $BASE_VERSION exists"
+              SKIP_CREATION=true
+            else
+              echo "::notice::Processing pre-release tag $TAG (no full release $BASE_VERSION found)"
+            fi
           else
             echo "::notice::Processing stable release tag: $TAG"
-            echo "is_prerelease=false" >> $GITHUB_OUTPUT
-            echo "tag=$TAG" >> $GITHUB_OUTPUT
+          fi
+          
+          # Set outputs based on whether we should skip
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          if [[ "$SKIP_CREATION" == "true" ]]; then
+            echo "skip_feature_branch_creation=true" >> $GITHUB_OUTPUT
+            echo "branch_name=" >> $GITHUB_OUTPUT
+          else
+            echo "skip_feature_branch_creation=false" >> $GITHUB_OUTPUT
             echo "branch_name=features-based-on-$TAG" >> $GITHUB_OUTPUT
           fi
 
   create-feature-branch:
     needs: check-tag
-    if: needs.check-tag.outputs.is_prerelease == 'false'
+    if: needs.check-tag.outputs.skip_feature_branch_creation == 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -86,12 +100,21 @@ jobs:
           
           for tag in $ALL_TAGS; do
             if [[ "$FOUND_CURRENT" == "true" ]]; then
-              # Skip pre-release tags (same pattern as above)
-              if [[ "$tag" =~ [\.-]?(rc|alpha|beta|pre|dev)[0-9]*$ ]]; then
-                echo "Skipping pre-release tag: $tag"
-                continue
-              fi
+              # Check if this is a pre-release tag
+              # Extract base version (e.g., v0.10.0 from v0.10.0rc1)
+              BASE_VERSION=$(bash tools/extract_base_version.sh "$tag")
               
+              if [[ "$tag" != "$BASE_VERSION" ]]; then
+                # This is a pre-release tag (base version differs from tag)
+                # Check if corresponding full release exists
+                if git ls-remote --tags origin | grep -q "refs/tags/$BASE_VERSION$"; then
+                  echo "Skipping pre-release tag $tag because full release $BASE_VERSION exists"
+                  continue
+                else
+                  echo "Considering pre-release tag $tag (no full release $BASE_VERSION found)"
+                fi
+              fi
+
               # This is a previous tag, check if it has a feature branch
               CANDIDATE_BRANCH="features-based-on-$tag"
               echo "Checking if branch exists for tag $tag: $CANDIDATE_BRANCH"
@@ -318,7 +341,7 @@ jobs:
             \`\`\`
 
           🎯 **No force push needed!**"
-          
+
           gh pr create \
             --title "Cherry-pick conflicts: $PREVIOUS_BRANCH_NAME → $BRANCH_NAME" \
             --body "$PR_BODY" \

--- a/.github/workflows/create-feature-branches.yml
+++ b/.github/workflows/create-feature-branches.yml
@@ -36,7 +36,7 @@ jobs:
           if [[ "$TAG" != "$BASE_VERSION" ]]; then
             # This is a pre-release tag (base version differs from tag)
             # Check if corresponding full release exists
-            if git ls-remote --tags https://${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git | grep -q "refs/tags/$BASE_VERSION$"; then
+            if git ls-remote --tags "https://${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" | grep -q "refs/tags/$BASE_VERSION$"; then
               echo "::notice::Skipping pre-release tag $TAG because full release $BASE_VERSION exists"
               SKIP_CREATION=true
             else
@@ -47,13 +47,17 @@ jobs:
           fi
           
           # Set outputs based on whether we should skip
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           if [[ "$SKIP_CREATION" == "true" ]]; then
-            echo "skip_feature_branch_creation=true" >> $GITHUB_OUTPUT
-            echo "branch_name=" >> $GITHUB_OUTPUT
+            {
+              echo "skip_feature_branch_creation=true"
+              echo "branch_name="
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "skip_feature_branch_creation=false" >> $GITHUB_OUTPUT
-            echo "branch_name=features-based-on-$TAG" >> $GITHUB_OUTPUT
+            {
+              echo "skip_feature_branch_creation=false"
+              echo "branch_name=features-based-on-$TAG"
+            } >> "$GITHUB_OUTPUT"
           fi
 
   create-feature-branch:
@@ -79,8 +83,10 @@ jobs:
       - name: Set tag variables
         id: get_tag
         run: |
-          echo "tag=${{ needs.check-tag.outputs.tag }}" >> $GITHUB_OUTPUT
-          echo "branch_name=${{ needs.check-tag.outputs.branch_name }}" >> $GITHUB_OUTPUT
+          {
+            echo "tag=${{ needs.check-tag.outputs.tag }}"
+            echo "branch_name=${{ needs.check-tag.outputs.branch_name }}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Find previous tag with existing branch
         id: previous_tag
@@ -98,7 +104,7 @@ jobs:
           echo "Searching for previous tag with existing feature branch..."
           echo "Current tag: $CURRENT_TAG"
           
-          for tag in $ALL_TAGS; do
+          while IFS= read -r tag; do
             if [[ "$FOUND_CURRENT" == "true" ]]; then
               # Check if this is a pre-release tag
               # Extract base version (e.g., v0.10.0 from v0.10.0rc1)
@@ -131,18 +137,22 @@ jobs:
               FOUND_CURRENT=true
               echo "Found current tag position in list"
             fi
-          done
+          done <<< "$ALL_TAGS"
           
           if [[ -z "$PREVIOUS_TAG_WITH_BRANCH" ]]; then
             echo "No previous tag with existing feature branch found"
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "tag=" >> $GITHUB_OUTPUT
-            echo "branch_name=" >> $GITHUB_OUTPUT
+            {
+              echo "exists=false"
+              echo "tag="
+              echo "branch_name="
+            } >> "$GITHUB_OUTPUT"
           else
             echo "Found previous tag with branch: $PREVIOUS_TAG_WITH_BRANCH"
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "tag=$PREVIOUS_TAG_WITH_BRANCH" >> $GITHUB_OUTPUT
-            echo "branch_name=$PREVIOUS_BRANCH_NAME" >> $GITHUB_OUTPUT
+            {
+              echo "exists=true"
+              echo "tag=$PREVIOUS_TAG_WITH_BRANCH"
+              echo "branch_name=$PREVIOUS_BRANCH_NAME"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check if current branch already exists
@@ -150,10 +160,10 @@ jobs:
         run: |
           BRANCH_NAME="${{ steps.get_tag.outputs.branch_name }}"
           if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Branch $BRANCH_NAME already exists"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "Branch $BRANCH_NAME does not exist"
           fi
 
@@ -172,15 +182,19 @@ jobs:
           
           if [[ -z "$COMMITS" ]]; then
             echo "No commits to cherry-pick"
-            echo "has_commits=false" >> $GITHUB_OUTPUT
-            echo "commits=" >> $GITHUB_OUTPUT
+            {
+              echo "has_commits=false"
+              echo "commits="
+            } >> "$GITHUB_OUTPUT"
           else
             echo "Commits to cherry-pick:"
             echo "$COMMITS"
-            echo "has_commits=true" >> $GITHUB_OUTPUT
             # Convert newlines to spaces for GitHub Actions
             COMMITS_ONELINE=$(echo "$COMMITS" | tr '\n' ' ')
-            echo "commits=$COMMITS_ONELINE" >> $GITHUB_OUTPUT
+            {
+              echo "has_commits=true"
+              echo "commits=$COMMITS_ONELINE"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create feature branch
@@ -206,7 +220,7 @@ jobs:
           
           # Try cherry-picking commits
           CONFLICT_OCCURRED=false
-          for commit in $COMMITS; do
+          while IFS= read -r commit; do
             echo "Cherry-picking commit: $commit"
             if ! git cherry-pick "$commit"; then
               echo "Conflict occurred while cherry-picking $commit"
@@ -215,13 +229,13 @@ jobs:
               git cherry-pick --abort
               break
             fi
-          done
+          done < <(tr ' ' '\n' <<< "$COMMITS")
           
           if [[ "$CONFLICT_OCCURRED" == "true" ]]; then
-            echo "conflict=true" >> $GITHUB_OUTPUT
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
             echo "Conflicts detected during cherry-pick"
           else
-            echo "conflict=false" >> $GITHUB_OUTPUT
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
             echo "All commits cherry-picked successfully"
           fi
 
@@ -240,7 +254,7 @@ jobs:
           git push origin "$PR_BRANCH"
           
           # Create PR using GitHub CLI or API
-          COMMIT_LIST_MD=$(echo $COMMITS | tr ' ' '\n' | while read commit; do echo "- $commit"; done)
+          COMMIT_LIST_MD=$(tr ' ' '\n' <<< "$COMMITS" | while IFS= read -r commit; do echo "- $commit"; done)
           
           # Create PR body content
           PR_BODY="## Cherry-pick: $PREVIOUS_BRANCH_NAME → $BRANCH_NAME
@@ -258,7 +272,7 @@ jobs:
             --title "Cherry-pick: $PREVIOUS_BRANCH_NAME → $BRANCH_NAME" \
             --body "$PR_BODY" \
             --base "$BRANCH_NAME" \
-            --head "$CONFLICT_BRANCH" \
+            --head "$PR_BRANCH" \
             --reviewer "CatherineSue,shenoyvvarun,slin1237,YouNeedCryDear,upfixer,key4ng"
         env:
           GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
@@ -277,7 +291,7 @@ jobs:
           git checkout -b "$CONFLICT_BRANCH" "$BRANCH_NAME"
           
           # Create an empty commit to establish the branch and enable PR creation
-          COMMIT_LIST=$(echo $COMMITS | tr ' ' '\n' | while read commit; do git log --oneline -1 $commit 2>/dev/null || echo $commit; done)
+          COMMIT_LIST=$(tr ' ' '\n' <<< "$COMMITS" | while IFS= read -r commit; do git log --oneline -1 "$commit" 2>/dev/null || echo "$commit"; done)
           
           # Now attempt the merge - conflicts will be left in proper Git state
           if ! git merge origin/"$PREVIOUS_BRANCH_NAME" --no-ff -m "Cherry-pick commits from $PREVIOUS_BRANCH_NAME"; then
@@ -308,7 +322,7 @@ jobs:
           fi
           
           # Create PR using GitHub CLI or API
-          COMMIT_LIST_MD=$(echo $COMMITS | tr ' ' '\n' | while read commit; do echo "- $commit"; done)
+          COMMIT_LIST_MD=$(tr ' ' '\n' <<< "$COMMITS" | while IFS= read -r commit; do echo "- $commit"; done)
           
           # Create PR body content
           PR_BODY="## 🚧 Cherry-pick Conflicts Need Resolution

--- a/.github/workflows/create-feature-branches.yml
+++ b/.github/workflows/create-feature-branches.yml
@@ -47,17 +47,14 @@ jobs:
           fi
           
           # Set outputs based on whether we should skip
+          # shellcheck disable=SC2129
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           if [[ "$SKIP_CREATION" == "true" ]]; then
-            {
-              echo "skip_feature_branch_creation=true"
-              echo "branch_name="
-            } >> "$GITHUB_OUTPUT"
+            echo "skip_feature_branch_creation=true" >> "$GITHUB_OUTPUT"
+            echo "branch_name=" >> "$GITHUB_OUTPUT"
           else
-            {
-              echo "skip_feature_branch_creation=false"
-              echo "branch_name=features-based-on-$TAG"
-            } >> "$GITHUB_OUTPUT"
+            echo "skip_feature_branch_creation=false" >> "$GITHUB_OUTPUT"
+            echo "branch_name=features-based-on-$TAG" >> "$GITHUB_OUTPUT"
           fi
 
   create-feature-branch:
@@ -83,10 +80,9 @@ jobs:
       - name: Set tag variables
         id: get_tag
         run: |
-          {
-            echo "tag=${{ needs.check-tag.outputs.tag }}"
-            echo "branch_name=${{ needs.check-tag.outputs.branch_name }}"
-          } >> "$GITHUB_OUTPUT"
+          # shellcheck disable=SC2129
+          echo "tag=${{ needs.check-tag.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          echo "branch_name=${{ needs.check-tag.outputs.branch_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Find previous tag with existing branch
         id: previous_tag
@@ -141,18 +137,16 @@ jobs:
           
           if [[ -z "$PREVIOUS_TAG_WITH_BRANCH" ]]; then
             echo "No previous tag with existing feature branch found"
-            {
-              echo "exists=false"
-              echo "tag="
-              echo "branch_name="
-            } >> "$GITHUB_OUTPUT"
+            # shellcheck disable=SC2129
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "branch_name=" >> "$GITHUB_OUTPUT"
           else
             echo "Found previous tag with branch: $PREVIOUS_TAG_WITH_BRANCH"
-            {
-              echo "exists=true"
-              echo "tag=$PREVIOUS_TAG_WITH_BRANCH"
-              echo "branch_name=$PREVIOUS_BRANCH_NAME"
-            } >> "$GITHUB_OUTPUT"
+            # shellcheck disable=SC2129
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$PREVIOUS_TAG_WITH_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "branch_name=$PREVIOUS_BRANCH_NAME" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check if current branch already exists
@@ -182,19 +176,17 @@ jobs:
           
           if [[ -z "$COMMITS" ]]; then
             echo "No commits to cherry-pick"
-            {
-              echo "has_commits=false"
-              echo "commits="
-            } >> "$GITHUB_OUTPUT"
+            # shellcheck disable=SC2129
+            echo "has_commits=false" >> "$GITHUB_OUTPUT"
+            echo "commits=" >> "$GITHUB_OUTPUT"
           else
             echo "Commits to cherry-pick:"
             echo "$COMMITS"
             # Convert newlines to spaces for GitHub Actions
             COMMITS_ONELINE=$(echo "$COMMITS" | tr '\n' ' ')
-            {
-              echo "has_commits=true"
-              echo "commits=$COMMITS_ONELINE"
-            } >> "$GITHUB_OUTPUT"
+            # shellcheck disable=SC2129
+            echo "has_commits=true" >> "$GITHUB_OUTPUT"
+            echo "commits=$COMMITS_ONELINE" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create feature branch

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -81,16 +81,53 @@ jobs:
 
           # Create PR using GitHub CLI
           gh pr create \
+            --repo "${{ github.repository }}" \
             --title "Sync from upstream ($(date +'%Y-%m-%d'))" \
             --body "Automated sync from upstream repository with conflicts resolved. Please review before merging." \
             --head "$BRANCH_NAME" \
-            --base main
+            --base "main" \
+            --reviewer "CatherineSue,shenoyvvarun,slin1237,YouNeedCryDear,upfixer,key4ng"
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Sync tags
         if: steps.sync_main.outcome == 'success' || steps.sync_main.outcome == 'failure'
+        id: sync_tags
         run: |
+          # Fetch tags from upstream
           git fetch upstream --tags
+
+          # Get list of new tags before pushing
+          NEW_TAGS=$(git tag --list | grep -v -F -f <(git ls-remote --tags origin | awk '{print $2}' | sed 's|refs/tags/||') || true)
+
+          # Push tags to origin
           git push origin --tags
+
+          # Save new tags for next step
+          if [ -n "$NEW_TAGS" ]; then
+            echo "new_tags<<EOF" >> $GITHUB_OUTPUT
+            echo "$NEW_TAGS" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "has_new_tags=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_new_tags=false" >> $GITHUB_OUTPUT
+          fi
         continue-on-error: true
+
+      - name: Trigger feature branch creation for new tags
+        if: steps.sync_tags.outputs.has_new_tags == 'true'
+        run: |
+          NEW_TAGS="${{ steps.sync_tags.outputs.new_tags }}"
+
+          # Trigger workflow for each new tag
+          while IFS= read -r tag; do
+            if [[ "$tag" =~ ^v[0-9] ]]; then
+              echo "Triggering feature branch creation for tag: $tag"
+              gh workflow run create-feature-branches.yml \
+                --repo ${{ github.repository }} \
+                --field tag="$tag"
+            fi
+          done <<< "$NEW_TAGS"
+        env:
+          GITHUB_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,96 @@
+name: Sync from Upstream
+
+on:
+  schedule:
+    # Run every 2 weeks (bi-weekly) on Sundays at 2 AM UTC
+    - cron: "0 2 * * 0/2"
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream https://github.com/vllm-project/vllm.git || true
+          git remote set-url upstream https://github.com/vllm-project/vllm.git
+
+      - name: Fetch upstream changes
+        run: |
+          git fetch upstream
+          git fetch origin
+
+      - name: Sync main branch
+        run: |
+          git checkout main
+
+          # Check if there are any new commits to sync
+          BEHIND_COUNT=$(git rev-list --count HEAD..upstream/main)
+          if [ "$BEHIND_COUNT" -eq 0 ]; then
+            echo "Already up to date with upstream. No sync needed."
+            echo "sync_needed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "sync_needed=true" >> $GITHUB_OUTPUT
+          echo "Found $BEHIND_COUNT commits behind upstream"
+
+          git rebase upstream/main || {
+            echo "Rebase conflict detected. Creating a PR instead."
+            git rebase --abort
+            exit 1
+          }
+          git push --force-with-lease origin main
+        continue-on-error: true
+        id: sync_main
+
+      - name: Create sync PR if rebase failed
+        if: steps.sync_main.outcome == 'failure' && steps.sync_main.outputs.sync_needed == 'true'
+        run: |
+          BRANCH_NAME="sync-upstream-$(date +'%Y%m%d-%H%M%S')"
+          git checkout -b "$BRANCH_NAME"
+
+          # Try to rebase again, this time we'll commit the conflicts
+          git rebase upstream/main || {
+            echo "Resolving rebase conflicts..."
+            git add .
+            git rebase --continue || {
+              git rebase --abort
+              git merge upstream/main --no-edit --allow-unrelated-histories || {
+                git add .
+                git commit -m "Resolve sync conflicts from upstream"
+              }
+            }
+          }
+          git push origin "$BRANCH_NAME"
+
+          # Create PR using GitHub CLI
+          gh pr create \
+            --title "Sync from upstream ($(date +'%Y-%m-%d'))" \
+            --body "Automated sync from upstream repository with conflicts resolved. Please review before merging." \
+            --head "$BRANCH_NAME" \
+            --base main
+        env:
+          GITHUB_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Sync tags
+        if: steps.sync_main.outcome == 'success' || steps.sync_main.outcome == 'failure'
+        run: |
+          git fetch upstream --tags
+          git push origin --tags
+        continue-on-error: true

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -98,7 +98,7 @@ jobs:
           ORIGIN_TAGS=$(mktemp)
           NEW_TAGS_FILE=$(mktemp)
           trap 'rm -f "$UPSTREAM_TAGS" "$ORIGIN_TAGS" "$NEW_TAGS_FILE"' EXIT
-          TAG_SYNC_NOT_BEFORE_EPOCH=1779494400 # 2026-05-23T00:00:00Z
+          TAG_SYNC_MIN_VERSION="v0.22.0"
 
           git ls-remote --tags upstream | awk '!/\^\{\}$/ {print $1, $2}' > "$UPSTREAM_TAGS"
           git ls-remote --tags origin | awk '!/\^\{\}$/ {print $1, $2}' > "$ORIGIN_TAGS"
@@ -108,23 +108,15 @@ jobs:
             origin_sha=$(awk -v ref="$ref" '$2 == ref {print $1}' "$ORIGIN_TAGS")
 
             if [ -z "$origin_sha" ]; then
+              earliest_tag=$(printf '%s\n%s\n' "$tag" "$TAG_SYNC_MIN_VERSION" | sort -V | head -n1)
+              if [ "$earliest_tag" != "$TAG_SYNC_MIN_VERSION" ]; then
+                echo "::notice::Skipping historical upstream tag $tag before $TAG_SYNC_MIN_VERSION to avoid backfilling old tags"
+                continue
+              fi
+
               echo "Inspecting new upstream tag: $tag"
               if ! git fetch --no-tags upstream "$ref:$ref"; then
                 echo "::warning::Skipping tag $tag because it could not be fetched from upstream"
-                continue
-              fi
-              tag_created=$(git for-each-ref --format='%(creatordate:iso-strict)' "$ref")
-              tag_created_epoch=$(git for-each-ref --format='%(creatordate:unix)' "$ref")
-
-              if [ -z "$tag_created_epoch" ]; then
-                echo "::warning::Skipping tag $tag because its creation date could not be determined"
-                git tag -d "$tag"
-                continue
-              fi
-
-              if [ "$tag_created_epoch" -lt "$TAG_SYNC_NOT_BEFORE_EPOCH" ]; then
-                echo "::notice::Skipping old upstream tag $tag from $tag_created to avoid backfilling historical tags"
-                git tag -d "$tag"
                 continue
               fi
 

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -94,19 +94,48 @@ jobs:
         if: steps.sync_main.outcome == 'success' || steps.sync_main.outcome == 'failure'
         id: sync_tags
         run: |
-          # Fetch tags from upstream
-          git fetch upstream --tags
+          UPSTREAM_TAGS=$(mktemp)
+          ORIGIN_TAGS=$(mktemp)
+          NEW_TAGS_FILE=$(mktemp)
+          trap 'rm -f "$UPSTREAM_TAGS" "$ORIGIN_TAGS" "$NEW_TAGS_FILE"' EXIT
+          TAG_SYNC_NOT_BEFORE_EPOCH=1779494400 # 2026-05-23T00:00:00Z
 
-          # Get list of new tags before pushing
-          NEW_TAGS=$(git tag --list | grep -v -F -f <(git ls-remote --tags origin | awk '{print $2}' | sed 's|refs/tags/||') || true)
+          git ls-remote --tags upstream | awk '!/\^\{\}$/ {print $1, $2}' > "$UPSTREAM_TAGS"
+          git ls-remote --tags origin | awk '!/\^\{\}$/ {print $1, $2}' > "$ORIGIN_TAGS"
 
-          # Push tags to origin
-          git push origin --tags
+          while read -r upstream_sha ref; do
+            tag="${ref#refs/tags/}"
+            origin_sha=$(awk -v ref="$ref" '$2 == ref {print $1}' "$ORIGIN_TAGS")
+
+            if [ -z "$origin_sha" ]; then
+              echo "Inspecting new upstream tag: $tag"
+              git fetch --no-tags upstream "$ref:$ref"
+              tag_created=$(git for-each-ref --format='%(creatordate:iso-strict)' "$ref")
+              tag_created_epoch=$(git for-each-ref --format='%(creatordate:unix)' "$ref")
+
+              if [ -z "$tag_created_epoch" ]; then
+                echo "::warning::Skipping tag $tag because its creation date could not be determined"
+                git tag -d "$tag"
+                continue
+              fi
+
+              if [ "$tag_created_epoch" -lt "$TAG_SYNC_NOT_BEFORE_EPOCH" ]; then
+                echo "::notice::Skipping old upstream tag $tag from $tag_created to avoid backfilling historical tags"
+                git tag -d "$tag"
+                continue
+              fi
+
+              git push origin "$ref"
+              echo "$tag" >> "$NEW_TAGS_FILE"
+            elif [ "$origin_sha" != "$upstream_sha" ]; then
+              echo "::warning::Skipping tag $tag because origin ($origin_sha) differs from upstream ($upstream_sha)"
+            fi
+          done < "$UPSTREAM_TAGS"
 
           # Save new tags for next step
-          if [ -n "$NEW_TAGS" ]; then
+          if [ -s "$NEW_TAGS_FILE" ]; then
             echo "new_tags<<EOF" >> $GITHUB_OUTPUT
-            echo "$NEW_TAGS" >> $GITHUB_OUTPUT
+            cat "$NEW_TAGS_FILE" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
             echo "has_new_tags=true" >> $GITHUB_OUTPUT
           else
@@ -130,4 +159,3 @@ jobs:
           done <<< "$NEW_TAGS"
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -133,12 +133,11 @@ jobs:
 
           # Save new tags for next step
           if [ -s "$NEW_TAGS_FILE" ]; then
-            {
-              echo "new_tags<<EOF"
-              cat "$NEW_TAGS_FILE"
-              echo "EOF"
-              echo "has_new_tags=true"
-            } >> "$GITHUB_OUTPUT"
+            # shellcheck disable=SC2129
+            echo "new_tags<<EOF" >> "$GITHUB_OUTPUT"
+            cat "$NEW_TAGS_FILE" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+            echo "has_new_tags=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_new_tags=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -109,7 +109,10 @@ jobs:
 
             if [ -z "$origin_sha" ]; then
               echo "Inspecting new upstream tag: $tag"
-              git fetch --no-tags upstream "$ref:$ref"
+              if ! git fetch --no-tags upstream "$ref:$ref"; then
+                echo "::warning::Skipping tag $tag because it could not be fetched from upstream"
+                continue
+              fi
               tag_created=$(git for-each-ref --format='%(creatordate:iso-strict)' "$ref")
               tag_created_epoch=$(git for-each-ref --format='%(creatordate:unix)' "$ref")
 
@@ -125,10 +128,14 @@ jobs:
                 continue
               fi
 
-              git push origin "$ref"
+              if ! git push origin "$ref"; then
+                echo "::warning::Skipping tag $tag because it could not be pushed to origin"
+                git tag -d "$tag"
+                continue
+              fi
               echo "$tag" >> "$NEW_TAGS_FILE"
             elif [ "$origin_sha" != "$upstream_sha" ]; then
-              echo "::warning::Skipping tag $tag because origin ($origin_sha) differs from upstream ($upstream_sha)"
+              echo "::warning::Skipping tag $tag because origin ($origin_sha) differs from upstream ($upstream_sha); reconcile this tag manually if upstream should be authoritative"
             fi
           done < "$UPSTREAM_TAGS"
 

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -98,7 +98,7 @@ jobs:
           ORIGIN_TAGS=$(mktemp)
           NEW_TAGS_FILE=$(mktemp)
           trap 'rm -f "$UPSTREAM_TAGS" "$ORIGIN_TAGS" "$NEW_TAGS_FILE"' EXIT
-          TAG_SYNC_MIN_VERSION="v0.22.0"
+          TAG_SYNC_MIN_VERSION="v0.21.0"
 
           git ls-remote --tags upstream | awk '!/\^\{\}$/ {print $1, $2}' > "$UPSTREAM_TAGS"
           git ls-remote --tags origin | awk '!/\^\{\}$/ {print $1, $2}' > "$ORIGIN_TAGS"

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -43,11 +43,11 @@ jobs:
           BEHIND_COUNT=$(git rev-list --count HEAD..upstream/main)
           if [ "$BEHIND_COUNT" -eq 0 ]; then
             echo "Already up to date with upstream. No sync needed."
-            echo "sync_needed=false" >> $GITHUB_OUTPUT
+            echo "sync_needed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "sync_needed=true" >> $GITHUB_OUTPUT
+          echo "sync_needed=true" >> "$GITHUB_OUTPUT"
           echo "Found $BEHIND_COUNT commits behind upstream"
 
           git rebase upstream/main || {
@@ -141,12 +141,14 @@ jobs:
 
           # Save new tags for next step
           if [ -s "$NEW_TAGS_FILE" ]; then
-            echo "new_tags<<EOF" >> $GITHUB_OUTPUT
-            cat "$NEW_TAGS_FILE" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-            echo "has_new_tags=true" >> $GITHUB_OUTPUT
+            {
+              echo "new_tags<<EOF"
+              cat "$NEW_TAGS_FILE"
+              echo "EOF"
+              echo "has_new_tags=true"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "has_new_tags=false" >> $GITHUB_OUTPUT
+            echo "has_new_tags=false" >> "$GITHUB_OUTPUT"
           fi
         continue-on-error: true
 
@@ -160,7 +162,7 @@ jobs:
             if [[ "$tag" =~ ^v[0-9] ]]; then
               echo "Triggering feature branch creation for tag: $tag"
               gh workflow run create-feature-branches.yml \
-                --repo ${{ github.repository }} \
+                --repo "${{ github.repository }}" \
                 --field tag="$tag"
             fi
           done <<< "$NEW_TAGS"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,12 +135,12 @@ ignore-hidden = false
 
 [tool.typos.default]
 extend-ignore-identifiers-re = [".*[Uu][Ee][0-9][Mm][0-9].*"]
+extend-ignore-re = ['--reviewer "[^"]+"']
 
 [tool.typos.default.extend-identifiers]
 bbc5b7ede = "bbc5b7ede"
 NOOPs = "NOOPs"
 nin_shortcut = "nin_shortcut"
-slin1237 = "slin1237"
 cudaDevAttrMaxSharedMemoryPerBlockOptin = "cudaDevAttrMaxSharedMemoryPerBlockOptin"
 
 depthwise_seperable_out_channel = "depthwise_seperable_out_channel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ extend-ignore-identifiers-re = [".*[Uu][Ee][0-9][Mm][0-9].*"]
 bbc5b7ede = "bbc5b7ede"
 NOOPs = "NOOPs"
 nin_shortcut = "nin_shortcut"
+slin1237 = "slin1237"
 cudaDevAttrMaxSharedMemoryPerBlockOptin = "cudaDevAttrMaxSharedMemoryPerBlockOptin"
 
 depthwise_seperable_out_channel = "depthwise_seperable_out_channel"

--- a/tools/extract_base_version.sh
+++ b/tools/extract_base_version.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Extract base version from a tag by removing pre-release suffixes
+# Example: v0.10.0rc1 -> v0.10.0
+# Example: v1.2.3-alpha2 -> v1.2.3
+# Example: v2.0.0.dev5 -> v2.0.0
+#
+# Usage: extract_base_version.sh <tag>
+#   tag: The version tag to process (e.g., v0.10.0rc1)
+#
+# Returns: The base version without pre-release suffix
+
+if [ -z "$1" ]; then
+  echo "Error: No tag provided" >&2
+  echo "Usage: $0 <tag>" >&2
+  exit 1
+fi
+
+TAG="$1"
+
+# Remove pre-release suffixes (rc, alpha, beta, pre, dev followed by optional numbers)
+# Matches: -rc1, .rc1, rc1, -alpha, .beta2, dev5, etc.
+echo "$TAG" | sed -E 's/[\.-]?(rc|alpha|beta|pre|dev)[0-9]*$//'
+


### PR DESCRIPTION
## Purpose

The upstream sync workflow can currently report overall success while the tag sync step is effectively stuck. The concrete blocker is the historical `v0.10.2rc1` tag: origin and upstream point that tag name at different objects, so `git fetch upstream --tags` fails with `would clobber existing tag`. Because the step is marked `continue-on-error`, main keeps syncing but newer upstream tags do not reach this repo and feature branch creation does not run for future releases.

This PR fixes the going-forward path only. It intentionally does not backfill the historical missing tags from the v0.10.2 through v0.21.x range.

## What changed

- Compare upstream and origin tag refs before fetching tags.
- Skip existing tag names whose object IDs differ, emitting a GitHub Actions warning that the tag needs manual reconciliation if upstream should be authoritative.
- Fetch missing tags one by one with `--no-tags` so one tag cannot pull or clobber unrelated tags.
- Add a version cutover guard at `v0.21.0` so old missing tags are noticed and skipped rather than backfilled, without relying on tag creation dates that are unavailable for lightweight tags.
- Push missing tags one by one and isolate per-tag fetch/push failures, so one transient tag failure does not stop later tags in the same run.
- Record only successfully pushed, post-cutover tags in `new_tags`, so `create-feature-branches.yml` is triggered only for newly synced going-forward tags.
- Make the tag-sync and feature-branch workflows pass the repo actionlint/typos checks.
- Fix the successful cherry-pick PR path to use the PR branch it created instead of the conflict-branch variable from the separate conflict path.

## Duplicate check

I checked open PRs with these searches and found no existing open PR addressing this fix:

- `sync-upstream tag conflict`
- `v0.10.2rc1`
- `upstream tag sync`
- `create feature branch tags`

## Test plan

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/sync-upstream.yml"); YAML.load_file(".github/workflows/create-feature-branches.yml"); puts "yaml ok"'` passes.
- `git diff --check` passes.
- `PRE_COMMIT_HOME=/private/tmp/pre-commit-cache-vllm-sync pre-commit run typos --all-files --hook-stage manual` passes.
- `PRE_COMMIT_HOME=/private/tmp/pre-commit-cache-vllm-sync pre-commit run actionlint --all-files --hook-stage manual` passes.
- `PRE_COMMIT_HOME=/private/tmp/pre-commit-cache-vllm-sync pre-commit run shellcheck --all-files --hook-stage manual` passes locally.
- GitHub Actions `pre-commit` passes on PR #14.
- Ran a local simulated origin/upstream repository test with:
  - an origin-only conflicting `v0.10.2rc1` tag,
  - an old missing `v0.10.2` tag before the version cutover,
  - a future lightweight `v0.22.0` tag after the version cutover pointing at an older commit.
- The simulation skipped the conflict, skipped the old missing tag, pushed only the future lightweight tag, and recorded only `v0.22.0` for downstream feature-branch triggering.

## AI assistance

AI assistance was used to prepare this workflow-only change.
